### PR TITLE
Add plausible link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" />
    
   <title>ChainSafe Files - Decentralized Cloud Storage</title>
+  <script defer data-domain="files.chainsafe.io" src="https://plausible.io/js/plausible.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
hey guys, if it wasn't mentioned to you already, marketing wants to use self-hosted analytics to get a sense of web traffic on our product mini sites. this pr adds the link to index.html